### PR TITLE
chore: Minor change to remove www from github url in Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,9 +4,9 @@ version = "0.1.25"
 edition = "2021"
 description = "CLI for DJs"
 license = "MIT OR Apache-2.0"
-documentation = "https://www.github.com/matiasbn/dj-wizard"
-homepage = "https://www.github.com/matiasbn/dj-wizard"
-repository = "https://www.github.com/matiasbn/dj-wizard"
+documentation = "https://github.com/matiasbn/dj-wizard"
+homepage = "https://github.com/matiasbn/dj-wizard"
+repository = "https://github.com/matiasbn/dj-wizard"
 rust-version = "1.78"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html


### PR DESCRIPTION
Github redirects to the address without www anyway, so let's put that in Cargo.toml See also https://github.com/szabgab/rust-digger/issues/96

You can find out info about all of your crates here: https://rust-digger.code-maven.com/users/matiasbn